### PR TITLE
chore(deps): bump golang from 1.16.0-alpine to 1.16.2-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.0-alpine AS build-env
+FROM golang:1.16.2-alpine AS build-env
 RUN GO111MODULE=on go get -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder
 
 FROM alpine:latest


### PR DESCRIPTION
Bumps golang from 1.16.0-alpine to 1.16.2-alpine.

Signed-off-by: dependabot[bot] <support@github.com>